### PR TITLE
Fix build on MacOS

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -85,13 +85,13 @@ pub fn build(b: *std.Build) void {
         .HAVE_CPU_TO_LE64 = null,
         .HAVE_DECL_STRCASECMP = 0,
         .HAVE_DECL_STRICMP = 0,
-        .HAVE_DECL_STRLCPY = 0,
+        .HAVE_DECL_STRLCPY = enabled(t.os.tag == .macos),
         .HAVE_DECL_STRNCASECMP = 0,
         .HAVE_DECL_STRNICMP = 0,
         .HAVE_DECL_STRNLEN = 0,
         .HAVE_DECL_STRRCHRNUL = 0,
         .HAVE_DECL_STRSEP = 0,
-        .HAVE_ENDIAN_H = 1,
+        .HAVE_ENDIAN_H = have(t.os.tag == .linux),
         .HAVE_FACCESSAT = 1,
         .HAVE_FCNTL_H = 1,
         .HAVE_FILENO = 1,
@@ -133,8 +133,8 @@ pub fn build(b: *std.Build) void {
         .HAVE_IO_H = null,
         .HAVE_ISASCII = 1,
         .HAVE_ISCNTRL = 1,
-        .HAVE_MACHINE_ENDIAN_H = 1,
-        .HAVE_MEMPCPY = 1,
+        .HAVE_MACHINE_ENDIAN_H = have(t.os.tag == .macos),
+        .HAVE_MEMPCPY = have(t.os.tag == .linux),
         .HAVE_MEMPSET = null,
         .HAVE_MINIX_CONFIG_H = null,
         .HAVE_MMAP = 1,
@@ -153,7 +153,7 @@ pub fn build(b: *std.Build) void {
         .HAVE_STRICMP = 1,
         .HAVE_STRINGS_H = 1,
         .HAVE_STRING_H = 1,
-        .HAVE_STRLCPY = null,
+        .HAVE_STRLCPY = have(t.os.tag == .macos),
         .HAVE_STRNCASECMP = 1,
         .HAVE_STRNICMP = 1,
         .HAVE_STRNLEN = 1,
@@ -162,7 +162,7 @@ pub fn build(b: *std.Build) void {
         .HAVE_STRUCT_STAT = null,
         .HAVE_STRUCT__STATI64 = null,
         .HAVE_SYSCONF = null,
-        .HAVE_SYS_ENDIAN_H = 1,
+        .HAVE_SYS_ENDIAN_H = have(t.os.tag == .linux),
         .HAVE_SYS_MMAN_H = 1,
         .HAVE_SYS_PARAM_H = null,
         .HAVE_SYS_RESOURCE_H = null,
@@ -172,7 +172,7 @@ pub fn build(b: *std.Build) void {
         .HAVE_TYPEOF = null,
         .HAVE_UINTPTR_T = 1,
         .HAVE_UNISTD_H = null,
-        .HAVE_VSNPRINTF = null,
+        .HAVE_VSNPRINTF = have(t.os.tag == .macos),
         .HAVE_WCHAR_H = null,
         .HAVE__ACCESS = null,
         .HAVE__BITSCANREVERSE = null,
@@ -335,6 +335,7 @@ pub fn build(b: *std.Build) void {
         "-DHAVE_CONFIG_H",
         "-std=c17",
         "-Wno-implicit-function-declaration",
+        "-Wno-int-conversion",
     });
     exe.linkLibC();
     b.installArtifact(exe);
@@ -342,4 +343,8 @@ pub fn build(b: *std.Build) void {
 
 fn have(c: bool) ?c_int {
     return if (c) 1 else null;
+}
+
+fn enabled(c: bool) ?c_int {
+    return if (c) 1 else 0;
 }


### PR DESCRIPTION
This changes some config flags dynamically based on the target os. It fixes some build errors on MacOS regarding the inclusion of `endian.h` on that platform. May need to do the same for Windows platform, but haven't set up that environment yet.
Eager to learn from this, so please let me know your thoughts if you have the time. Thanks!

Related to https://github.com/andrewrk/ffmpeg/issues/6